### PR TITLE
bugfix: move retry connection to when we build the client

### DIFF
--- a/VERSION.json
+++ b/VERSION.json
@@ -1,23 +1,23 @@
 {
-  "version": "23.3.2",
-  "notes": "See full release notes here: https://github.com/spyglass-search/spyglass/releases/tag/v2023.3.2",
-  "pub_date": "2023-03-16T23:41:04Z",
+  "version": "23.3.1",
+  "notes": "See full release notes here: https://github.com/spyglass-search/spyglass/releases/tag/v2023.3.1",
+  "pub_date": "2023-03-10T04:10:25Z",
   "platforms": {
     "darwin-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSRk9WYXdDUXphYnJuSURBNkRSY09vbXRwN0hnOHpaN05neGpXMFBnUUdSMnQxWElKQllCa3JTWTM2cndHZ2FuK24wUHl4bkRNZUd0L0R5ZklhalZ1M3A1QzhxUFRUWkFVPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNjc5MDA5MjI4CWZpbGU6U3B5Z2xhc3MuYXBwLnRhci5negpEZDFMbXF0eklabVd6MzVRUTNIUEVoZk5zQVA2VnVjVzdiRDM3L1NJaWt2eWRJMmdpb0wxYmVnSmJTQmxTYVkyR09XU3UxT1hmQTlUM1lRMlhDTmZCUT09Cg==",
-      "url": "https://github.com/spyglass-search/spyglass/releases/download/v2023.3.2/Spyglass_universal.app.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSRk9WYXdDUXphYnIxcFZRYWRnNFhYaytnUzZoQnpoa1RoSXB6YXU0bnZ3VkVJZ0YzOXI5aG1kaCs1bWhQbEs2b2tUTVdGUTAyL1JKeDZaVTh3OG16NWowUGkza01oRkFFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNjc4NDEzMTU3CWZpbGU6U3B5Z2xhc3MuYXBwLnRhci5negpCbGhCVHI0Uk51b1JwVXpaY1dzbE83VE8vRnNJNlFjZGJabmc2bnhTa2l3K0UrR1F1SGtYY292em1hL0dBL29ZZU9DSCtreDltOUt6dVpPZkpCK1ZEdz09Cg==",
+      "url": "https://github.com/spyglass-search/spyglass/releases/download/v2023.3.1/Spyglass_universal.app.tar.gz"
     },
     "darwin-aarch64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSRk9WYXdDUXphYnJuSURBNkRSY09vbXRwN0hnOHpaN05neGpXMFBnUUdSMnQxWElKQllCa3JTWTM2cndHZ2FuK24wUHl4bkRNZUd0L0R5ZklhalZ1M3A1QzhxUFRUWkFVPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNjc5MDA5MjI4CWZpbGU6U3B5Z2xhc3MuYXBwLnRhci5negpEZDFMbXF0eklabVd6MzVRUTNIUEVoZk5zQVA2VnVjVzdiRDM3L1NJaWt2eWRJMmdpb0wxYmVnSmJTQmxTYVkyR09XU3UxT1hmQTlUM1lRMlhDTmZCUT09Cg==",
-      "url": "https://github.com/spyglass-search/spyglass/releases/download/v2023.3.2/Spyglass_universal.app.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSRk9WYXdDUXphYnIxcFZRYWRnNFhYaytnUzZoQnpoa1RoSXB6YXU0bnZ3VkVJZ0YzOXI5aG1kaCs1bWhQbEs2b2tUTVdGUTAyL1JKeDZaVTh3OG16NWowUGkza01oRkFFPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNjc4NDEzMTU3CWZpbGU6U3B5Z2xhc3MuYXBwLnRhci5negpCbGhCVHI0Uk51b1JwVXpaY1dzbE83VE8vRnNJNlFjZGJabmc2bnhTa2l3K0UrR1F1SGtYY292em1hL0dBL29ZZU9DSCtreDltOUt6dVpPZkpCK1ZEdz09Cg==",
+      "url": "https://github.com/spyglass-search/spyglass/releases/download/v2023.3.1/Spyglass_universal.app.tar.gz"
     },
     "linux-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSRk9WYXdDUXphYnFudW5tZUpnOUZ4aFRYbkVLd21ZYVMzbStKeUs5UkFuYzdTVCtmeXd6T3dKVHlDdlBmQytndTJ0TzdycDlhaUpBNWx6SkIrV0tMdThIUERBbitOR0E0PQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNjc5MDA2ODg1CWZpbGU6c3B5Z2xhc3NfMjMuMy4yX2FtZDY0LkFwcEltYWdlLnRhci5nego3enBHb3hKRXZ3emZEeHFLNmxiU1NsaVFZaDZ1czZFRk5GMlA3RkQ5L1hSRDM0M3p2NkRza2tEWU9sWmpaTnhMckpIRGVZQWxLbFdnajd6cUpZcU9DQT09Cg==",
-      "url": "https://github.com/spyglass-search/spyglass/releases/download/v2023.3.2/spyglass_23.3.2_amd64.AppImage.tar.gz"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSRk9WYXdDUXphYmpOdFdzc29sNGxjYUxUbDRRTlk5YUM3aGI4RlYzZU8xR0JYc2VKZi8zaDgySm1maGpWUlp4V2UrMzB0ekRsSFltSVZKM0J1NUNoZGdlRTBNR0tma1FzPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNjc4NDA5ODM1CWZpbGU6c3B5Z2xhc3NfMjMuMy4xX2FtZDY0LkFwcEltYWdlLnRhci5negpId1ZIQzVWY1IzcHBhK1daYml0bmUyQm9nYkQ5bk15dy9jZTA2RnF6S3BrRVVpNUM5dTc5NmwraVE3UmZScklnSXdiNnJsYTJmdG1hVjhXNDhNSTRCZz09Cg==",
+      "url": "https://github.com/spyglass-search/spyglass/releases/download/v2023.3.1/spyglass_23.3.1_amd64.AppImage.tar.gz"
     },
     "windows-x86_64": {
-      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSRk9WYXdDUXphYmd0c0Nyc3BaSkd6VmdpQ3Ridm1wbVcyV1lDa3VuU3BRMnM0djdsdVJwQkxMMFFGN2JsQjV4RmpqVTFTRnorVlFQRUNOTnN0OEZLUTNJUjVkdWQ4V2dvPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNjc5MDA4NDUzCWZpbGU6U3B5Z2xhc3NfMjMuMy4yX3g2NF9lbi1VUy5tc2kuemlwClVsR0g1c3hhajJlUlpJZGxUcFUwb2NBaGZZVDM5aEZhak10bUFySXBlUUx3VC9XVHhoL3NoWmFrYkJFblBUYVRZM00xSnkraTBlNmNZc3gwSTh0dUFBPT0K",
-      "url": "https://github.com/spyglass-search/spyglass/releases/download/v2023.3.2/Spyglass_23.3.2_x64_en-US.msi.zip"
+      "signature": "dW50cnVzdGVkIGNvbW1lbnQ6IHNpZ25hdHVyZSBmcm9tIHRhdXJpIHNlY3JldCBrZXkKUlVSRk9WYXdDUXphYmt0dXFxZklsWXdGak4zYWRLSnp5ZzkzbHB4MVV0Tm5mRzErdk9LdjBINnJzOHRVZUF3SHpaOGtNenVkWUFtb2FndTZxRjNjbGRka3F5OS9YbmV4eVFBPQp0cnVzdGVkIGNvbW1lbnQ6IHRpbWVzdGFtcDoxNjc4NDEwNTQyCWZpbGU6U3B5Z2xhc3NfMjMuMy4xX3g2NF9lbi1VUy5tc2kuemlwCkhsMTYzSG9OT0dHTmtBaFNlVzR0QUxMRzY4NGRRalU1enI1NmxOZVE1K2lRMzl4bGxiK2dWYTkwQWY2dlNWZWx3OGl1SDUvejZla2h3QTN0STVPRERRPT0K",
+      "url": "https://github.com/spyglass-search/spyglass/releases/download/v2023.3.1/Spyglass_23.3.1_x64_en-US.msi.zip"
     }
   }
 }

--- a/crates/tauri/entitlements.plist
+++ b/crates/tauri/entitlements.plist
@@ -8,5 +8,7 @@
     <key>com.apple.security.personal-information.addressbook</key><true/>
     <key>com.apple.security.personal-information.calendars</key><true/>
     <key>com.apple.security.personal-information.photos-library</key><true/>
+    <key>com.apple.security.network.client</key><true/>
+    <key>com.apple.security.network.server</key><true/>
   </dict>
 </plist><?xml version="1.0" encoding="UTF-8"?>

--- a/crates/tauri/src/rpc.rs
+++ b/crates/tauri/src/rpc.rs
@@ -35,6 +35,7 @@ async fn try_connect(endpoint: &str) -> anyhow::Result<WsClient> {
     let retry_strategy = FixedInterval::from_millis(5000).take(4);
     match Retry::spawn(retry_strategy, || {
         WsClientBuilder::default()
+            .connection_timeout(std::time::Duration::from_secs(10))
             .request_timeout(std::time::Duration::from_secs(10))
             .build(endpoint)
     })

--- a/crates/tauri/src/rpc.rs
+++ b/crates/tauri/src/rpc.rs
@@ -30,23 +30,23 @@ pub struct SpyglassServerClient {
 
 /// Build client & attempt a connection to the health check endpoint.
 async fn try_connect(endpoint: &str) -> anyhow::Result<WsClient> {
-    match WsClientBuilder::default()
-        .request_timeout(std::time::Duration::from_secs(30))
-        .build(endpoint)
-        .await
+    log::info!("connecting to backend via {}", endpoint);
+    // Wait until we have a connection
+    let retry_strategy = FixedInterval::from_millis(5000).take(4);
+    match Retry::spawn(retry_strategy, || {
+        WsClientBuilder::default()
+            .request_timeout(std::time::Duration::from_secs(10))
+            .build(endpoint)
+    })
+    .await
     {
         Ok(client) => {
-            // Wait until we have a connection
-            let retry_strategy = FixedInterval::from_millis(5000).take(4);
-            match Retry::spawn(retry_strategy, || client.protocol_version()).await {
-                Ok(v) => {
-                    log::info!("connected to daemon w/ version: {}", v);
-                    Ok(client)
-                }
-                Err(err) => Err(anyhow::anyhow!(err.to_string())),
-            }
+            let v = client.protocol_version().await;
+            log::info!("connected to daemon w/ version: {:?}", v);
+            Ok(client)
         }
         Err(e) => {
+            log::warn!("error connecting: {:?}", e);
             sentry::capture_error(&e);
             Err(anyhow::anyhow!(e.to_string()))
         }
@@ -91,7 +91,6 @@ impl SpyglassServerClient {
         #[cfg(not(debug_assertions))]
         let sidecar_handle = Some(SpyglassServerClient::check_and_start_backend());
 
-        log::info!("backend started");
         let client = match try_connect(&endpoint).await {
             Ok(client) => Some(client),
             Err(err) => {


### PR DESCRIPTION
Now that we're using websockets, the connection retry should be when we create the client