### PR TITLE
Update tantivy to 0.19 and add migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1602,7 +1602,8 @@ dependencies = [
  "shared",
  "strum 0.24.1",
  "strum_macros 0.24.3",
- "tantivy",
+ "tantivy 0.18.1",
+ "tantivy 0.19.2",
  "thiserror",
  "tokio",
  "url",
@@ -1711,8 +1712,22 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8dff2ee906bb242438742b5ecac909c0719cbd9db546f6c3d9ac86bd93f5b07e"
 dependencies = [
- "tantivy-bitpacker",
- "tantivy-common",
+ "tantivy-bitpacker 0.2.0",
+ "tantivy-common 0.3.0",
+]
+
+[[package]]
+name = "fastfield_codecs"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "374a3a53c1bd5fb31b10084229290eafb0a05f260ec90f1f726afffda4877a8a"
+dependencies = [
+ "fastdivide",
+ "itertools",
+ "log",
+ "ownedbytes 0.4.0",
+ "tantivy-bitpacker 0.3.0",
+ "tantivy-common 0.4.0",
 ]
 
 [[package]]
@@ -3729,7 +3744,8 @@ dependencies = [
  "rayon",
  "sea-orm-migration",
  "shared",
- "tantivy",
+ "tantivy 0.18.1",
+ "tantivy 0.19.2",
  "tar",
  "url",
 ]
@@ -4335,6 +4351,15 @@ name = "ownedbytes"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2981bd7cfb2a70e6c50083c60561275a269fc7458f151c53b126ec1b15cc040"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "ownedbytes"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e957eaa64a299f39755416e5b3128c505e9d63a91d0453771ad2ccd3907f8db"
 dependencies = [
  "stable_deref_trait",
 ]
@@ -6518,7 +6543,7 @@ dependencies = [
  "spyglass-rpc",
  "strum 0.24.1",
  "strum_macros 0.24.3",
- "tantivy",
+ "tantivy 0.19.2",
  "tendril",
  "thiserror",
  "tokio",
@@ -7018,7 +7043,7 @@ dependencies = [
  "downcast-rs",
  "fail",
  "fastdivide",
- "fastfield_codecs",
+ "fastfield_codecs 0.2.0",
  "fnv",
  "fs2",
  "htmlescape",
@@ -7033,7 +7058,7 @@ dependencies = [
  "num_cpus",
  "once_cell",
  "oneshot",
- "ownedbytes",
+ "ownedbytes 0.3.0",
  "pretty_assertions",
  "rayon",
  "regex",
@@ -7042,10 +7067,62 @@ dependencies = [
  "serde_json",
  "smallvec",
  "stable_deref_trait",
- "tantivy-bitpacker",
- "tantivy-common",
- "tantivy-fst",
- "tantivy-query-grammar",
+ "tantivy-bitpacker 0.2.0",
+ "tantivy-common 0.3.0",
+ "tantivy-fst 0.3.0",
+ "tantivy-query-grammar 0.18.0",
+ "tempfile",
+ "thiserror",
+ "time 0.3.17",
+ "uuid 1.2.2",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb26a6b22c84d8be41d99a14016d6f04d30d8d31a2ea411a8ab553af5cc490d"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "async-trait",
+ "base64 0.13.1",
+ "bitpacking",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs",
+ "fail",
+ "fastdivide",
+ "fastfield_codecs 0.3.1",
+ "fs2",
+ "htmlescape",
+ "itertools",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "murmurhash32",
+ "num_cpus",
+ "once_cell",
+ "oneshot",
+ "ownedbytes 0.4.0",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "smallvec",
+ "stable_deref_trait",
+ "tantivy-bitpacker 0.3.0",
+ "tantivy-common 0.4.0",
+ "tantivy-fst 0.4.0",
+ "tantivy-query-grammar 0.19.0",
  "tempfile",
  "thiserror",
  "time 0.3.17",
@@ -7060,13 +7137,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90f95c862d26a32e1fdb161ab139c5a3bba221f5fac512af40034e13e25f3131"
 
 [[package]]
+name = "tantivy-bitpacker"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e71a0c95b82d4292b097a09b989a6380d28c3a86800c841a2d03bae1fc8b9fa6"
+
+[[package]]
 name = "tantivy-common"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dec19155b3ed963ae1653bc4995ab8175281f68400c39081205ae25b53fd9750"
 dependencies = [
  "byteorder",
- "ownedbytes",
+ "ownedbytes 0.3.0",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14fef4182bb60df9a4b92cd8ecab39ba2e50a05542934af17eef1f49660705cb"
+dependencies = [
+ "byteorder",
+ "ownedbytes 0.4.0",
 ]
 
 [[package]]
@@ -7081,10 +7174,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "tantivy-fst"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc3c506b1a8443a3a65352df6382a1fb6a7afe1a02e871cee0d25e2c3d5f3944"
+dependencies = [
+ "byteorder",
+ "regex-syntax 0.6.28",
+ "utf8-ranges",
+]
+
+[[package]]
 name = "tantivy-query-grammar"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d6bbdce99f2b8dcbe24ee25acffb36a2b45b31344531374df1008f6a64bb583"
+dependencies = [
+ "combine",
+ "once_cell",
+ "regex",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "343e3ada4c1c480953f6960f8a21ce9c76611480ffdd4f4e230fdddce0fc5331"
 dependencies = [
  "combine",
  "once_cell",

--- a/crates/entities/Cargo.toml
+++ b/crates/entities/Cargo.toml
@@ -16,7 +16,8 @@ serde_json = "1.0"
 shared = { path = "../shared" }
 strum = "0.24"
 strum_macros = "0.24"
-tantivy = "0.18"
+tantivy_18 = { package="tantivy", version="0.18" }
+tantivy = "0.19"
 thiserror = "1.0.38"
 tokio = { version = "1", features = ["full"] }
 url = "2.2"

--- a/crates/entities/src/models/mod.rs
+++ b/crates/entities/src/models/mod.rs
@@ -11,6 +11,7 @@ pub mod lens;
 pub mod link;
 pub mod processed_files;
 pub mod resource_rule;
+pub mod schema;
 pub mod tag;
 
 use shared::config::Config;

--- a/crates/entities/src/models/schema/mod.rs
+++ b/crates/entities/src/models/schema/mod.rs
@@ -1,0 +1,3 @@
+pub mod v1;
+pub mod v2;
+pub mod v3;

--- a/crates/entities/src/models/schema/v2.rs
+++ b/crates/entities/src/models/schema/v2.rs
@@ -1,14 +1,10 @@
-use tantivy::schema::*;
+use tantivy_18::schema::*;
 
 pub type FieldName = String;
-
-/// The current schema version
-pub const SCHEMA_VERSION: &str = "4";
 pub struct SchemaMapping {
     pub text_fields: Option<Vec<(FieldName, TextOptions)>>,
-    pub date_fields: Option<Vec<(FieldName, DateOptions)>>,
-    pub unsigned_fields: Option<Vec<(FieldName, NumericOptions)>>,
 }
+
 pub trait SearchDocument {
     fn as_field_vec() -> SchemaMapping;
 
@@ -26,18 +22,6 @@ pub fn mapping_to_schema(mapping: &SchemaMapping) -> Schema {
             schema_builder.add_text_field(name, opts.clone());
         }
     }
-
-    if let Some(fields) = &mapping.date_fields {
-        for (name, opts) in fields {
-            schema_builder.add_date_field(name, opts.clone());
-        }
-    }
-
-    if let Some(fields) = &mapping.unsigned_fields {
-        for (name, opts) in fields {
-            schema_builder.add_u64_field(name, opts.clone());
-        }
-    }
     schema_builder.build()
 }
 
@@ -49,9 +33,6 @@ pub struct DocFields {
     pub description: Field,
     pub title: Field,
     pub url: Field,
-    pub tags: Field,
-    pub published: Field,
-    pub lastmodified: Field,
 }
 
 impl SearchDocument for DocFields {
@@ -78,31 +59,6 @@ impl SearchDocument for DocFields {
                 // Indexed
                 ("content".into(), TEXT | STORED),
             ]),
-            date_fields: Some(vec![
-                (
-                    "published".into(),
-                    DateOptions::default()
-                        .set_precision(DatePrecision::Microseconds)
-                        .set_fast(Cardinality::SingleValue)
-                        .set_indexed()
-                        .set_stored(),
-                ),
-                (
-                    "lastmodified".into(),
-                    DateOptions::default()
-                        .set_precision(DatePrecision::Microseconds)
-                        .set_fast(Cardinality::SingleValue)
-                        .set_indexed()
-                        .set_stored(),
-                ),
-            ]),
-            unsigned_fields: Some(vec![(
-                "tags".into(),
-                NumericOptions::default()
-                    .set_fast(Cardinality::MultiValues)
-                    .set_indexed()
-                    .set_stored(),
-            )]),
         }
     }
 
@@ -117,13 +73,6 @@ impl SearchDocument for DocFields {
                 .expect("No description in schema"),
             title: schema.get_field("title").expect("No title in schema"),
             url: schema.get_field("url").expect("No url in schema"),
-            tags: schema.get_field("tags").expect("No tags in schema"),
-            published: schema
-                .get_field("published")
-                .expect("No published date in schema"),
-            lastmodified: schema
-                .get_field("lastmodified")
-                .expect("No last modified date in schema"),
         }
     }
 }

--- a/crates/entities/src/models/schema/v3.rs
+++ b/crates/entities/src/models/schema/v3.rs
@@ -1,0 +1,212 @@
+use std::{collections::HashMap, path::PathBuf};
+
+use tantivy_18::{
+    collector::TopDocs, directory::MmapDirectory, query::TermQuery, schema::*, Index, IndexReader,
+    ReloadPolicy, TantivyError,
+};
+
+pub type FieldName = String;
+pub struct SchemaMapping {
+    pub text_fields: Option<Vec<(FieldName, TextOptions)>>,
+    pub unsigned_fields: Option<Vec<(FieldName, NumericOptions)>>,
+}
+
+pub trait SearchDocument {
+    fn as_field_vec() -> SchemaMapping;
+
+    fn as_schema() -> Schema {
+        mapping_to_schema(&Self::as_field_vec())
+    }
+
+    fn as_fields() -> Self;
+}
+
+pub fn mapping_to_schema(mapping: &SchemaMapping) -> Schema {
+    let mut schema_builder = Schema::builder();
+    if let Some(fields) = &mapping.text_fields {
+        for (name, opts) in fields {
+            schema_builder.add_text_field(name, opts.clone());
+        }
+    }
+
+    if let Some(fields) = &mapping.unsigned_fields {
+        for (name, opts) in fields {
+            schema_builder.add_u64_field(name, opts.clone());
+        }
+    }
+    schema_builder.build()
+}
+
+#[derive(Clone)]
+pub struct DocFields {
+    pub id: Field,
+    pub domain: Field,
+    pub content: Field,
+    pub description: Field,
+    pub title: Field,
+    pub url: Field,
+    pub tags: Field,
+}
+
+impl SearchDocument for DocFields {
+    fn as_field_vec() -> SchemaMapping {
+        // FAST:    Fast fields can be random-accessed rapidly. Use this for fields useful
+        //          for scoring, filtering, or collection.
+        // TEXT:    Means the field should be tokenized and indexed, along with its term
+        //          frequency and term positions.
+        // STRING:  Means the field will be untokenized and indexed unlike above
+        //
+        // STORED:  Means that the field will also be saved in a compressed, row oriented
+        //          key-value store. This store is useful to reconstruct the documents that
+        //          were selected during the search phase.
+        SchemaMapping {
+            text_fields: Some(vec![
+                // Used to reference this document
+                ("id".into(), STRING | STORED | FAST),
+                // Document contents
+                ("domain".into(), STRING | STORED | FAST),
+                ("title".into(), TEXT | STORED | FAST),
+                // Used for display purposes
+                ("description".into(), TEXT | STORED),
+                ("url".into(), STRING | STORED | FAST),
+                // Indexed
+                ("content".into(), TEXT | STORED),
+            ]),
+            unsigned_fields: Some(vec![(
+                "tags".into(),
+                NumericOptions::default()
+                    .set_fast(Cardinality::MultiValues)
+                    .set_indexed()
+                    .set_stored(),
+            )]),
+        }
+    }
+
+    fn as_fields() -> Self {
+        let schema = Self::as_schema();
+        Self {
+            id: schema.get_field("id").expect("No id in schema"),
+            domain: schema.get_field("domain").expect("No domain in schema"),
+            content: schema.get_field("content").expect("No content in schema"),
+            description: schema
+                .get_field("description")
+                .expect("No description in schema"),
+            title: schema.get_field("title").expect("No title in schema"),
+            url: schema.get_field("url").expect("No url in schema"),
+            tags: schema.get_field("tags").expect("No tags in schema"),
+        }
+    }
+}
+
+/// Represents the Third version of the index schema. Note that the
+/// import is for tantivy 0.18 since version V3 requires version 0.18
+pub struct SchemaReader {
+    reader: Option<IndexReader>,
+}
+
+impl SchemaReader {
+    pub fn new(path: &PathBuf) -> Self {
+        match reader(path) {
+            Ok(reader) => Self {
+                reader: Some(reader),
+            },
+            Err(err) => {
+                log::error!("Error initializing reader for V3 schema {:?}", err);
+                Self { reader: None }
+            }
+        }
+    }
+
+    /// Indicates if the reader was able to initialize
+    pub fn has_reader(&self) -> bool {
+        self.reader.is_some()
+    }
+
+    /// Returns a map of all text values for the specified document, the key is
+    /// the field name and the value is the field value.
+    pub fn get_txt_values(&self, doc_id: &str) -> HashMap<String, String> {
+        let txt_fields = DocFields::as_field_vec().text_fields.unwrap();
+        let mut map = HashMap::new();
+
+        if let Some(reader) = &self.reader {
+            let searcher = reader.searcher();
+            let schema = searcher.schema();
+            let id_field = schema.get_field("id").unwrap();
+
+            if let Some(doc) = get_by_id(id_field, reader, doc_id) {
+                for (name, _) in txt_fields {
+                    let old_value = doc
+                        .get_first(schema.get_field(name.as_str()).unwrap())
+                        .unwrap()
+                        .as_text()
+                        .unwrap();
+
+                    map.insert(name, old_value.into());
+                }
+            }
+        }
+        map
+    }
+
+    /// Returns a map of all unsigned values for the specified document (as of this version this is only a list of tags),
+    /// the key is the field name and the value is the field value.
+    pub fn get_unsigned_fields(&self, doc_id: &str) -> HashMap<String, Vec<u64>> {
+        let unsigned_fields = DocFields::as_field_vec().unsigned_fields.unwrap();
+        let mut map = HashMap::new();
+
+        if let Some(reader) = &self.reader {
+            let searcher = reader.searcher();
+            let schema = searcher.schema();
+            let id_field = schema.get_field("id").unwrap();
+
+            if let Some(doc) = get_by_id(id_field, reader, doc_id) {
+                for (name, _) in unsigned_fields {
+                    let old_value = doc
+                        .get_all(schema.get_field(name.as_str()).unwrap())
+                        .filter_map(|val| val.as_u64())
+                        .collect::<Vec<u64>>();
+
+                    map.insert(name, old_value);
+                }
+            }
+        }
+
+        map
+    }
+}
+
+/// Helper method used to get the document by id
+fn get_by_id(id_field: Field, reader: &IndexReader, doc_id: &str) -> Option<Document> {
+    let searcher = reader.searcher();
+
+    let query = TermQuery::new(
+        Term::from_field_text(id_field, doc_id),
+        IndexRecordOption::Basic,
+    );
+
+    let res = searcher
+        .search(&query, &TopDocs::with_limit(1))
+        .expect("Unable to execute query");
+
+    if res.is_empty() {
+        return None;
+    }
+
+    let (_, doc_address) = res.first().expect("No results in search");
+    if let Ok(doc) = searcher.doc(*doc_address) {
+        return Some(doc);
+    }
+    None
+}
+
+/// Helper to build a reader that is compatible with schema version 3
+pub fn reader(path: &PathBuf) -> Result<IndexReader, TantivyError> {
+    let dir = MmapDirectory::open(path).expect("Unable to mmap search index");
+    let mapping = DocFields::as_field_vec();
+    let index = Index::open_or_create(dir, mapping_to_schema(&mapping))?;
+
+    index
+        .reader_builder()
+        .reload_policy(ReloadPolicy::Manual)
+        .try_into()
+}

--- a/crates/migrations/Cargo.toml
+++ b/crates/migrations/Cargo.toml
@@ -15,6 +15,7 @@ log = "0.4"
 rayon = "1.5"
 sea-orm-migration = { version = "0.11" }
 shared = { path = "../shared" }
-tantivy = "0.18"
+tantivy_18 = { package="tantivy", version="0.18" }
+tantivy = "0.19"
 tar = "0.4"
 url = "2.3"

--- a/crates/migrations/src/lib.rs
+++ b/crates/migrations/src/lib.rs
@@ -29,6 +29,7 @@ mod m20230131_000001_add_is_syncing_to_connection_table;
 mod m20230201_000001_add_tag_index;
 mod m20230203_000001_add_indexed_document_index;
 mod m20230220_000001_remove_legacy_plugins;
+mod m20230315_000001_migrate_search_schema;
 mod utils;
 
 pub struct Migrator;
@@ -63,6 +64,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20230201_000001_add_tag_index::Migration),
             Box::new(m20230203_000001_add_indexed_document_index::Migration),
             Box::new(m20230220_000001_remove_legacy_plugins::Migration),
+            Box::new(m20230315_000001_migrate_search_schema::Migration),
         ]
     }
 }

--- a/crates/migrations/src/m20220823_000001_migrate_search_schema.rs
+++ b/crates/migrations/src/m20220823_000001_migrate_search_schema.rs
@@ -1,19 +1,20 @@
 use std::path::PathBuf;
 use std::time::Instant;
 
+use entities::models::schema::v1::{self, SearchDocument as SearchDocumentV1};
+use entities::models::schema::v2::{self, SearchDocument as SearchDocumentV2};
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
 use sea_orm_migration::prelude::*;
-use tantivy::collector::TopDocs;
-use tantivy::directory::MmapDirectory;
-use tantivy::query::TermQuery;
-use tantivy::TantivyError;
-use tantivy::{schema::*, IndexWriter};
-use tantivy::{Index, IndexReader, ReloadPolicy};
+use tantivy_18::collector::TopDocs;
+use tantivy_18::directory::MmapDirectory;
+use tantivy_18::query::TermQuery;
+use tantivy_18::TantivyError;
+use tantivy_18::{schema::*, IndexWriter};
+use tantivy_18::{Index, IndexReader, ReloadPolicy};
 
 // use entities::schema::DocFields;
 use entities::models::crawl_queue;
-use entities::schema::{mapping_to_schema, SchemaMapping};
 use entities::sea_orm::{ConnectionTrait, Statement};
 use shared::config::Config;
 
@@ -21,28 +22,13 @@ use crate::utils::migration_utils;
 
 pub struct Migration;
 impl Migration {
-    pub fn before_schema(&self) -> SchemaMapping {
-        SchemaMapping {
-            text_fields: Some(vec![
-                // Used to reference this document
-                ("id".into(), STRING | STORED),
-                // Document contents
-                ("domain".into(), STRING | STORED),
-                ("title".into(), TEXT | STORED),
-                ("description".into(), TEXT | STORED),
-                ("url".into(), STRING | STORED),
-                // Indexed but don't store for retreival
-                ("content".into(), TEXT),
-                // Stored but not indexed
-                ("raw".into(), STORED.into()),
-            ]),
-            unsigned_fields: None,
-        }
+    pub fn before_schema(&self) -> v1::SchemaMapping {
+        v1::DocFields::as_field_vec()
     }
 
     pub fn before_reader(&self, path: &PathBuf) -> Result<IndexReader, TantivyError> {
         let dir = MmapDirectory::open(path).expect("Unable to mmap search index");
-        let index = Index::open_or_create(dir, mapping_to_schema(&self.before_schema()))?;
+        let index = Index::open_or_create(dir, v1::mapping_to_schema(&self.before_schema()))?;
 
         index
             .reader_builder()
@@ -50,25 +36,13 @@ impl Migration {
             .try_into()
     }
 
-    pub fn after_schema(&self) -> SchemaMapping {
-        SchemaMapping {
-            text_fields: Some(vec![
-                ("id".into(), STRING | STORED | FAST),
-                // Document contents
-                ("domain".into(), STRING | STORED | FAST),
-                ("title".into(), TEXT | STORED | FAST),
-                ("description".into(), TEXT | STORED),
-                ("url".into(), STRING | STORED | FAST),
-                // Indexed
-                ("content".into(), TEXT | STORED),
-            ]),
-            unsigned_fields: None,
-        }
+    pub fn after_schema(&self) -> v2::SchemaMapping {
+        v2::DocFields::as_field_vec()
     }
 
     pub fn after_writer(&self, path: &PathBuf) -> IndexWriter {
         let dir = MmapDirectory::open(path).expect("Unable to mmap search index");
-        let index = Index::open_or_create(dir, mapping_to_schema(&self.after_schema()))
+        let index = Index::open_or_create(dir, v2::mapping_to_schema(&self.after_schema()))
             .expect("Unable to open search index");
 
         index.writer(50_000_000).expect("Unable to create writer")
@@ -170,8 +144,8 @@ impl MigrationTrait for Migration {
 
         println!("Migrating index @ {old_index_path:?} to {new_index_path:?}");
 
-        let old_schema = mapping_to_schema(&self.before_schema());
-        let new_schema = mapping_to_schema(&self.after_schema());
+        let old_schema = v1::mapping_to_schema(&self.before_schema());
+        let new_schema = v2::mapping_to_schema(&self.after_schema());
         let old_reader_res = self.before_reader(&old_index_path);
         if let Err(err) = old_reader_res {
             // Potentially already migrated?

--- a/crates/migrations/src/m20230315_000001_migrate_search_schema.rs
+++ b/crates/migrations/src/m20230315_000001_migrate_search_schema.rs
@@ -1,0 +1,180 @@
+use std::path::PathBuf;
+use std::time::Instant;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+use entities::models::schema::v3::SchemaReader;
+use entities::schema::DocFields;
+use sea_orm_migration::prelude::*;
+use tantivy::directory::MmapDirectory;
+use tantivy::DateTime;
+use tantivy::{schema::*, IndexWriter, Index};
+
+use entities::schema::{mapping_to_schema, SchemaMapping, SearchDocument};
+use entities::sea_orm::{ConnectionTrait, Statement};
+use shared::config::Config;
+
+use crate::utils::migration_utils;
+pub struct Migration;
+impl Migration {
+    pub fn after_schema(&self) -> SchemaMapping {
+        DocFields::as_field_vec()
+    }
+
+    pub fn after_writer(&self, path: &PathBuf) -> IndexWriter {
+        let dir = MmapDirectory::open(path).expect("Unable to mmap search index");
+        let index = Index::open_or_create(dir, mapping_to_schema(&self.after_schema()))
+            .expect("Unable to open search index");
+
+        index.writer(50_000_000).expect("Unable to create writer")
+    }
+
+    pub fn migrate_document(
+        &self,
+        doc_id: &str,
+        old_schema: &SchemaReader,
+        new_schema: &Schema,
+    ) -> Document {
+        let mut new_doc = Document::default();
+        new_doc.add_text(new_schema.get_field("id").unwrap(), doc_id);
+
+        let txt_vals = old_schema.get_txt_values(doc_id);
+        let unsigned_vals = old_schema.get_unsigned_fields(doc_id);
+
+        for (old_field, new_field) in &[
+            // Will map <old> -> <new>
+            ("domain", "domain"),
+            ("title", "title"),
+            ("description", "description"),
+            // No content was saved previous, so we'll use the description as a stopgap
+            // and recrawl stuff
+            ("content", "content"),
+            ("url", "url"),
+            ("tags", "tags"),
+        ] {
+            let new_field = new_schema.get_field(new_field).unwrap();
+
+            if let Some(old_value) = txt_vals.get(old_field.to_owned()) {
+                new_doc.add_text(new_field, old_value);
+            }
+
+            if let Some(old_value) = unsigned_vals.get(old_field.to_owned()) {
+                for val in old_value {
+                    new_doc.add_u64(new_field, *val);
+                }
+            }
+        }
+
+        let start = SystemTime::now();
+        let unix_time = start
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards");
+
+        let date_time = DateTime::from_timestamp_millis(unix_time.as_millis() as i64);
+
+        new_doc.add_date(
+            new_schema.get_field("published").unwrap(),
+            date_time,
+        );
+        new_doc.add_date(new_schema.get_field("lastmodified").unwrap(), date_time);
+
+        new_doc
+    }
+}
+
+impl MigrationName for Migration {
+    fn name(&self) -> &str {
+        "m20230315_000001_migrate_search_schema"
+    }
+}
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let result = manager
+            .get_connection()
+            .query_all(Statement::from_string(
+                manager.get_database_backend(),
+                "SELECT id, doc_id, url FROM indexed_document".to_owned(),
+            ))
+            .await?;
+
+        let config = Config::new();
+        let old_index_path = config.index_dir();
+        // No docs yet, nothing to migrate.
+        if result.is_empty() {
+            // Removing the old index folder will also remove any metadata that lingers
+            // from an empty index.
+            let _ = std::fs::remove_dir_all(old_index_path);
+            return Ok(());
+        }
+
+        let new_index_path = old_index_path
+            .parent()
+            .expect("Expected parent path")
+            .join("migrated_index");
+
+        if !new_index_path.exists() {
+            if let Err(e) = std::fs::create_dir(new_index_path.clone()) {
+                return Err(DbErr::Custom(format!("Can't create new index: {e}")));
+            }
+        }
+
+        println!("Migrating index @ {old_index_path:?} to {new_index_path:?}");
+
+        let old_schema = SchemaReader::new(&old_index_path);
+        let new_schema = mapping_to_schema(&self.after_schema());
+        if !old_schema.has_reader() {
+            // Potentially already migrated?
+            println!("Error opening index");
+            return Ok(());
+        }
+
+        let mut new_writer = self.after_writer(&new_index_path);
+
+        let now = Instant::now();
+
+        let _errs = result
+            .iter()
+            .filter_map(|row| {
+                let doc_id: String = row.try_get::<String>("", "doc_id").unwrap();
+
+                if let Err(e) = new_writer.add_document(self.migrate_document(
+                    &doc_id,
+                    &old_schema,
+                    &new_schema,
+                )) {
+                    log::error!("Error migrating doc {:?}", e);
+                    return Some(DbErr::Custom(format!("Unable to migrate doc: {e}")));
+                }
+
+                None
+            })
+            .collect::<Vec<DbErr>>();
+
+        // Save change to new index
+        if let Err(e) = new_writer.commit() {
+            return Err(DbErr::Custom(format!("Unable to commit changes: {e}")));
+        }
+
+        if let Err(e) = migration_utils::backup_dir(&old_index_path) {
+            return Err(DbErr::Custom(format!("Unable to backup old index: {e}")));
+        }
+
+        // Move new index into place.
+        if let Err(e) = migration_utils::replace_dir(&new_index_path, &old_index_path) {
+            return Err(DbErr::Custom(format!(
+                "Unable to move new index into place: {e}"
+            )));
+        }
+
+        let elapsed_time = now.elapsed();
+        println!("Migration took {} seconds.", elapsed_time.as_secs());
+
+        Ok(())
+    }
+
+    async fn down(&self, _: &SchemaManager) -> Result<(), DbErr> {
+        Ok(())
+    }
+}

--- a/crates/migrations/src/m20230315_000001_migrate_search_schema.rs
+++ b/crates/migrations/src/m20230315_000001_migrate_search_schema.rs
@@ -8,7 +8,7 @@ use entities::schema::DocFields;
 use sea_orm_migration::prelude::*;
 use tantivy::directory::MmapDirectory;
 use tantivy::DateTime;
-use tantivy::{schema::*, IndexWriter, Index};
+use tantivy::{schema::*, Index, IndexWriter};
 
 use entities::schema::{mapping_to_schema, SchemaMapping, SearchDocument};
 use entities::sea_orm::{ConnectionTrait, Statement};
@@ -72,10 +72,7 @@ impl Migration {
 
         let date_time = DateTime::from_timestamp_millis(unix_time.as_millis() as i64);
 
-        new_doc.add_date(
-            new_schema.get_field("published").unwrap(),
-            date_time,
-        );
+        new_doc.add_date(new_schema.get_field("published").unwrap(), date_time);
         new_doc.add_date(new_schema.get_field("lastmodified").unwrap(), date_time);
 
         new_doc

--- a/crates/spyglass/Cargo.toml
+++ b/crates/spyglass/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 strum = "0.24"
 strum_macros = "0.24"
-tantivy = "0.18"
+tantivy = "0.19"
 tendril = "0.4.2"
 thiserror = "1.0.37"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
[x] Update from tantivy 0.18 to 0.19
[x] Add index migration to convert 0.18 compatible index to 0.19 compatible index
[x] Add in new date fields to the index schema, (published, lastmodified)