### PR TITLE
tweak: toggle hide/show w/ hotkey & recenter window on resize

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6559,6 +6559,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "url",
+ "windows 0.39.0",
 ]
 
 [[package]]

--- a/crates/tauri/Cargo.toml
+++ b/crates/tauri/Cargo.toml
@@ -52,6 +52,9 @@ rev = "6c63c49e29e670343b71fee455e1a6c9145f4a8e"
 cocoa = "0.24"
 objc = "0.2.7"
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.39.0", features = ["Win32_Foundation", "Win32_UI_WindowsAndMessaging"] }
+
 [features]
 default = [ "custom-protocol" ]
 custom-protocol = [ "tauri/custom-protocol" ]

--- a/crates/tauri/src/cmd.rs
+++ b/crates/tauri/src/cmd.rs
@@ -14,12 +14,7 @@ use shared::config::{Config, UserSettings};
 use shared::{event::ClientEvent, request, response};
 use spyglass_rpc::RpcClient;
 
-#[cfg(target_os = "linux")]
-use super::platform::linux::os_open;
-#[cfg(target_os = "macos")]
-use super::platform::mac::os_open;
-#[cfg(target_os = "windows")]
-use super::platform::windows::os_open;
+use super::platform::os_open;
 
 mod settings;
 pub use settings::*;

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -22,10 +22,10 @@ use tracing_log::LogTracer;
 use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
 
 use diff::Diff;
+use platform::os_open;
 use shared::config::{Config, UserSettings};
 use shared::metrics::{Event, Metrics};
 use spyglass_rpc::RpcClient;
-use platform::os_open;
 
 mod cmd;
 mod constants;

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -25,13 +25,7 @@ use diff::Diff;
 use shared::config::{Config, UserSettings};
 use shared::metrics::{Event, Metrics};
 use spyglass_rpc::RpcClient;
-
-#[cfg(target_os = "linux")]
-use platform::linux::os_open;
-#[cfg(target_os = "macos")]
-use platform::mac::os_open;
-#[cfg(target_os = "windows")]
-use platform::windows::os_open;
+use platform::os_open;
 
 mod cmd;
 mod constants;

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -356,7 +356,7 @@ fn register_global_shortcut(window: &Window, app_handle: &AppHandle, settings: &
     // Register global shortcut
     let mut shortcuts = app_handle.global_shortcut_manager();
     if let Err(error) = shortcuts.unregister_all() {
-        log::info!("Unable to unregister all shortcuts {:?}", error);
+        log::warn!("Unable to unregister all shortcuts {:?}", error);
     }
 
     match shortcuts.is_registered(&settings.shortcut) {
@@ -366,7 +366,13 @@ fn register_global_shortcut(window: &Window, app_handle: &AppHandle, settings: &
                 let app_hand = app_handle.clone();
                 if let Err(e) = shortcuts.register(&settings.shortcut, move || {
                     let window = window::get_searchbar(&app_hand);
-                    window::show_search_bar(&window);
+                    if window.is_maximized().unwrap_or_default()
+                        || window.is_visible().unwrap_or_default()
+                    {
+                        window::hide_search_bar(&window)
+                    } else {
+                        window::show_search_bar(&window);
+                    }
                 }) {
                     window::alert(window, "Error registering global shortcut", &format!("{e}"));
                 }

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -366,9 +366,7 @@ fn register_global_shortcut(window: &Window, app_handle: &AppHandle, settings: &
                 let app_hand = app_handle.clone();
                 if let Err(e) = shortcuts.register(&settings.shortcut, move || {
                     let window = window::get_searchbar(&app_hand);
-                    if window.is_maximized().unwrap_or_default()
-                        || window.is_visible().unwrap_or_default()
-                    {
+                    if platform::is_visible(&window) {
                         window::hide_search_bar(&window)
                     } else {
                         window::show_search_bar(&window);

--- a/crates/tauri/src/platform/linux.rs
+++ b/crates/tauri/src/platform/linux.rs
@@ -4,6 +4,10 @@ use tauri::api::process::current_binary;
 use tauri::{Env, Window};
 use url::Url;
 
+pub fn is_visible(window: &Window) {
+    window.is_visible().unwrap_or_default()
+}
+
 pub fn show_search_bar(window: &Window) {
     let _ = window.show();
     let _ = window.unminimize();

--- a/crates/tauri/src/platform/linux.rs
+++ b/crates/tauri/src/platform/linux.rs
@@ -4,7 +4,7 @@ use tauri::api::process::current_binary;
 use tauri::{Env, Window};
 use url::Url;
 
-pub fn is_visible(window: &Window) {
+pub fn is_visible(window: &Window) -> bool {
     window.is_visible().unwrap_or_default()
 }
 

--- a/crates/tauri/src/platform/mac.rs
+++ b/crates/tauri/src/platform/mac.rs
@@ -4,6 +4,10 @@ use url::Url;
 
 use crate::window;
 
+pub fn is_visible(window: &Window) -> bool {
+    window.is_visible().unwrap_or_default()
+}
+
 pub fn show_search_bar(window: &Window) {
     let _ = tauri::AppHandle::show(&window.app_handle());
     let _ = window.set_focus();

--- a/crates/tauri/src/platform/mac.rs
+++ b/crates/tauri/src/platform/mac.rs
@@ -6,8 +6,8 @@ use crate::window;
 
 pub fn show_search_bar(window: &Window) {
     let _ = tauri::AppHandle::show(&window.app_handle());
-    window::center_search_bar(window);
     let _ = window.set_focus();
+    window::center_search_bar(window);
 }
 
 pub fn hide_search_bar(window: &Window) {

--- a/crates/tauri/src/platform/mod.rs
+++ b/crates/tauri/src/platform/mod.rs
@@ -11,6 +11,6 @@ pub use mac::*;
 pub mod mac;
 
 #[cfg(target_os = "windows")]
-pub use windows::*;
-#[cfg(target_os = "windows")]
 pub mod windows;
+#[cfg(target_os = "windows")]
+pub use self::windows::*;

--- a/crates/tauri/src/platform/mod.rs
+++ b/crates/tauri/src/platform/mod.rs
@@ -1,7 +1,16 @@
 /// Platform specific implementation of things
+///
+#[cfg(target_os = "linux")]
+pub use linux::*;
 #[cfg(target_os = "linux")]
 pub mod linux;
+
+#[cfg(target_os = "macos")]
+pub use mac::*;
 #[cfg(target_os = "macos")]
 pub mod mac;
+
+#[cfg(target_os = "windows")]
+pub use windows::*;
 #[cfg(target_os = "windows")]
 pub mod windows;

--- a/crates/tauri/src/platform/mod.rs
+++ b/crates/tauri/src/platform/mod.rs
@@ -1,16 +1,16 @@
 /// Platform specific implementation of things
 ///
 #[cfg(target_os = "linux")]
-pub use linux::*;
+mod linux;
 #[cfg(target_os = "linux")]
-pub mod linux;
+pub use self::linux::*;
 
 #[cfg(target_os = "macos")]
-pub use mac::*;
+mod mac;
 #[cfg(target_os = "macos")]
-pub mod mac;
+pub use self::mac::*;
 
 #[cfg(target_os = "windows")]
-pub mod windows;
+mod windows;
 #[cfg(target_os = "windows")]
 pub use self::windows::*;

--- a/crates/tauri/src/platform/windows.rs
+++ b/crates/tauri/src/platform/windows.rs
@@ -4,16 +4,19 @@ use tauri::Window;
 use url::Url;
 use windows::Win32::Foundation::HWND;
 use windows::Win32::UI::WindowsAndMessaging::GetWindowPlacement;
-use windows::Win32::UI::WindowsAndMessaging::WINDOWPLACEMENT;
+use windows::Win32::UI::WindowsAndMessaging::{SHOW_WINDOW_CMD, WINDOWPLACEMENT};
 
-pub fn is_visible(window: &Window) {
+pub fn is_visible(window: &Window) -> bool {
     if let Ok(handle) = window.hwnd() {
         let mut lpwndpl = WINDOWPLACEMENT::default();
         unsafe {
-            let _ = GetWindowPlacement(handle, &lpwndpl);
-            dbg!(lpwndpl);
+            let _ = GetWindowPlacement::<HWND>(handle, &mut lpwndpl);
+            // SHOW_WINDOW_CMD(2) == minimized
+            return lpwndpl.showCmd != SHOW_WINDOW_CMD(2);
         }
     }
+
+    false
 }
 
 pub fn show_search_bar(window: &Window) {

--- a/crates/tauri/src/platform/windows.rs
+++ b/crates/tauri/src/platform/windows.rs
@@ -2,6 +2,19 @@ use crate::window;
 use shared::event::ClientEvent;
 use tauri::Window;
 use url::Url;
+use windows::Win32::Foundation::HWND;
+use windows::Win32::UI::WindowsAndMessaging::GetWindowPlacement;
+use windows::Win32::UI::WindowsAndMessaging::WINDOWPLACEMENT;
+
+pub fn is_visible(window: &Window) {
+    if let Ok(handle) = window.hwnd() {
+        let mut lpwndpl = WINDOWPLACEMENT::default();
+        unsafe {
+            let _ = GetWindowPlacement(handle, &lpwndpl);
+            dbg!(lpwndpl);
+        }
+    }
+}
 
 pub fn show_search_bar(window: &Window) {
     let _ = window.show();

--- a/crates/tauri/src/plugins/startup.rs
+++ b/crates/tauri/src/plugins/startup.rs
@@ -119,6 +119,6 @@ async fn run_and_check_backend(app_handle: AppHandle) {
         show_wizard_window(&window.app_handle());
     } else {
         let sbar = get_searchbar(&app_handle);
-        let _ = sbar.show();
+        window::show_search_bar(&sbar);
     }
 }

--- a/crates/tauri/src/window.rs
+++ b/crates/tauri/src/window.rs
@@ -69,7 +69,6 @@ pub fn get_searchbar(app: &AppHandle) -> Window {
     if let Some(window) = app.get_window(constants::SEARCH_WIN_NAME) {
         window
     } else {
-        let default_height = 101.0;
         let window =
             WindowBuilder::new(app, constants::SEARCH_WIN_NAME, WindowUrl::App("/".into()))
                 .menu(get_app_menu())
@@ -78,7 +77,7 @@ pub fn get_searchbar(app: &AppHandle) -> Window {
                 .transparent(true)
                 .visible(false)
                 .disable_file_drop_handler()
-                .inner_size(640.0, default_height)
+                .inner_size(640.0, 108.0)
                 .build()
                 .expect("Unable to create searchbar window");
 

--- a/crates/tauri/src/window.rs
+++ b/crates/tauri/src/window.rs
@@ -112,7 +112,7 @@ pub fn get_searchbar(app: &AppHandle) -> Window {
 }
 
 pub async fn resize_window(window: &Window, height: f64) {
-    if let Some(monitor) = find_monitor(window) {
+    let new_size = if let Some(monitor) = find_monitor(window) {
         let size = monitor.size();
         let scale = monitor.scale_factor();
         let monitor_height = size.height as f64 - (constants::INPUT_Y * scale);
@@ -120,19 +120,21 @@ pub async fn resize_window(window: &Window, height: f64) {
         // If the requested height is greater than the monitor size, use the monitor
         // height so we don't go offscreen.
         let height = monitor_height.min(height);
-
-        let _ = window.set_size(Size::Physical(PhysicalSize {
+        Size::Physical(PhysicalSize {
             width: (constants::INPUT_WIDTH * scale) as u32,
             height: (height * scale) as u32,
-        }));
+        })
     } else {
         log::warn!("Unable to detect monitor size, resizing using defaults");
-        // No monitor info available so just set!
-        let _ = window.set_size(Size::Physical(PhysicalSize {
+        Size::Physical(PhysicalSize {
             width: constants::INPUT_WIDTH as u32,
             height: height as u32,
-        }));
-    }
+        })
+    };
+
+    // recenter after resize
+    let _ = window.set_size(new_size);
+    center_search_bar(window);
 }
 
 fn show_window(window: &Window) {

--- a/crates/tauri/src/window.rs
+++ b/crates/tauri/src/window.rs
@@ -50,14 +50,7 @@ pub fn center_search_bar(window: &Window) {
 }
 
 pub fn show_search_bar(window: &Window) {
-    #[cfg(target_os = "linux")]
-    platform::linux::show_search_bar(window);
-
-    #[cfg(target_os = "macos")]
-    platform::mac::show_search_bar(window);
-
-    #[cfg(target_os = "windows")]
-    platform::windows::show_search_bar(window);
+    platform::show_search_bar(window);
 
     // Wait a little bit for the window to show being focusing on it.
     let window = window.clone();
@@ -68,14 +61,7 @@ pub fn show_search_bar(window: &Window) {
 }
 
 pub fn hide_search_bar(window: &Window) {
-    #[cfg(target_os = "linux")]
-    platform::linux::hide_search_bar(window);
-
-    #[cfg(target_os = "macos")]
-    platform::mac::hide_search_bar(window);
-
-    #[cfg(target_os = "windows")]
-    platform::windows::hide_search_bar(window);
+    platform::hide_search_bar(window);
 }
 
 /// Builds or returns the main searchbar window


### PR DESCRIPTION
- Using the hotkey while spyglass is open will close it (like Spotlight on macOS)
- Fix an issue where the searchbar is not recentered after alt-tabbing away