### PR TITLE
Action status is not shown when action is executed

### DIFF
--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -150,9 +150,7 @@ impl SearchPage {
                 // the execute_action is set. To allow the user to see a status change that indicates
                 // something actually happened we need to delay it for a little bit.
                 Timeout::new(250, move || {
-                    spawn_local(async move {
-                        link.send_message(Msg::UserActionComplete(label));
-                    });
+                    link.send_message(Msg::UserActionComplete(label));
                 })
                 .forget();
             });

--- a/crates/client/src/pages/search.rs
+++ b/crates/client/src/pages/search.rs
@@ -143,9 +143,18 @@ impl SearchPage {
             let link = link.clone();
             let selected = selected.clone();
             spawn_local(async move {
-                let label = &action_def.label.clone();
+                let label = action_def.label.clone();
                 components::user_action_list::execute_action(selected, action_def).await;
-                link.send_message(Msg::UserActionComplete(label.to_owned()));
+
+                // The action is asynchronous making the firing of UserActionComplete instantly after
+                // the execute_action is set. To allow the user to see a status change that indicates
+                // something actually happened we need to delay it for a little bit.
+                Timeout::new(250, move || {
+                    spawn_local(async move {
+                        link.send_message(Msg::UserActionComplete(label));
+                    });
+                })
+                .forget();
             });
 
             self.show_actions = false;


### PR DESCRIPTION
The action status is set then unset before it can be displayed on the client. Added a short timeout to allow the display to render long enough to view.