### PR TITLE
tweak: update searcher to return Document struct instead of doc addr

### DIFF
--- a/crates/spyglass/bin/debug/src/main.rs
+++ b/crates/spyglass/bin/debug/src/main.rs
@@ -10,7 +10,7 @@ use tracing_log::LogTracer;
 use tracing_subscriber::{fmt, layer::SubscriberExt, EnvFilter};
 
 use libspyglass::pipeline::cache_pipeline::process_update;
-use spyglass_searcher::{document_to_struct, IndexPath, QueryBoost, QueryStats, Searcher};
+use spyglass_searcher::{IndexPath, QueryBoost, QueryStats, Searcher};
 
 #[cfg(debug_assertions)]
 const LOG_LEVEL: &str = "spyglassdebug=DEBUG";
@@ -129,21 +129,12 @@ async fn main() -> anyhow::Result<ExitCode> {
                     if docs.is_empty() {
                         println!("No indexed document for url {:?}", &doc.url);
                     } else {
-                        for (_score, doc_addr) in docs {
-                            if let Ok(Some(doc)) = index
-                                .reader
-                                .searcher()
-                                .doc(doc_addr)
-                                .map(|doc| document_to_struct(&doc))
-                            {
-                                println!(
-                                    "Indexed Document: {}",
-                                    ron::ser::to_string_pretty(&doc, PrettyConfig::new())
-                                        .unwrap_or_default()
-                                );
-                            } else {
-                                println!("Error accessing Doc at address {:?}", doc_addr);
-                            }
+                        for (_score, doc) in docs {
+                            println!(
+                                "Indexed Document: {}",
+                                ron::ser::to_string_pretty(&doc, PrettyConfig::new())
+                                    .unwrap_or_default()
+                            );
                         }
                     }
                 }

--- a/crates/spyglass/src/api/handler/search.rs
+++ b/crates/spyglass/src/api/handler/search.rs
@@ -10,7 +10,7 @@ use shared::metrics;
 use shared::request;
 use shared::response::{LensResult, SearchLensesResp, SearchMeta, SearchResult, SearchResults};
 use spyglass_searcher::schema::{DocFields, SearchDocument};
-use spyglass_searcher::{document_to_struct, QueryBoost, QueryStats};
+use spyglass_searcher::{QueryBoost, QueryStats};
 use std::collections::HashSet;
 use std::time::SystemTime;
 use tracing::instrument;
@@ -58,54 +58,52 @@ pub async fn search_docs(
     let mut results: Vec<SearchResult> = Vec::new();
     let mut missing: Vec<(String, String)> = Vec::new();
 
-    for (score, doc_addr) in docs {
-        if let Ok(Some(doc)) = searcher.doc(doc_addr).map(|doc| document_to_struct(&doc)) {
-            log::debug!("Got id with url {} {}", doc.doc_id, doc.url);
-            let indexed = indexed_document::Entity::find()
-                .filter(indexed_document::Column::DocId.eq(doc.doc_id.clone()))
-                .one(&state.db)
-                .await;
+    for (score, doc) in docs {
+        log::debug!("Got id with url {} {}", doc.doc_id, doc.url);
+        let indexed = indexed_document::Entity::find()
+            .filter(indexed_document::Column::DocId.eq(doc.doc_id.clone()))
+            .one(&state.db)
+            .await;
 
-            let crawl_uri = doc.url;
-            match indexed {
-                Ok(Some(indexed)) => {
-                    let tags = indexed
-                        .find_related(tag::Entity)
-                        .all(&state.db)
-                        .await
-                        .unwrap_or_default()
-                        .iter()
-                        .map(|tag| (tag.label.to_string(), tag.value.clone()))
-                        .collect::<Vec<(String, String)>>();
+        let crawl_uri = doc.url;
+        match indexed {
+            Ok(Some(indexed)) => {
+                let tags = indexed
+                    .find_related(tag::Entity)
+                    .all(&state.db)
+                    .await
+                    .unwrap_or_default()
+                    .iter()
+                    .map(|tag| (tag.label.to_string(), tag.value.clone()))
+                    .collect::<Vec<(String, String)>>();
 
-                    let fields = DocFields::as_fields();
-                    let tokenizer = index
-                        .index
-                        .tokenizer_for_field(fields.content)
-                        .expect("Unable to get tokenizer for content field");
+                let fields = DocFields::as_fields();
+                let tokenizer = index
+                    .index
+                    .tokenizer_for_field(fields.content)
+                    .expect("Unable to get tokenizer for content field");
 
-                    let description = spyglass_searcher::utils::generate_highlight_preview(
-                        &tokenizer,
-                        &query,
-                        &doc.content,
-                    );
+                let description = spyglass_searcher::utils::generate_highlight_preview(
+                    &tokenizer,
+                    &query,
+                    &doc.content,
+                );
 
-                    let result = SearchResult {
-                        doc_id: doc.doc_id.clone(),
-                        domain: doc.domain,
-                        title: doc.title,
-                        crawl_uri: crawl_uri.clone(),
-                        description,
-                        url: indexed.open_url.unwrap_or(crawl_uri),
-                        tags,
-                        score,
-                    };
+                let result = SearchResult {
+                    doc_id: doc.doc_id.clone(),
+                    domain: doc.domain,
+                    title: doc.title,
+                    crawl_uri: crawl_uri.clone(),
+                    description,
+                    url: indexed.open_url.unwrap_or(crawl_uri),
+                    tags,
+                    score,
+                };
 
-                    results.push(result);
-                }
-                _ => {
-                    missing.push((doc.doc_id.to_owned(), crawl_uri.to_owned()));
-                }
+                results.push(result);
+            }
+            _ => {
+                missing.push((doc.doc_id.to_owned(), crawl_uri.to_owned()));
             }
         }
     }


### PR DESCRIPTION
Cleans up the superfluous DocAddr -> Document conversions that were happening outside of the searcher module