### PR TITLE
tweak: always transcribe audio to original language

### DIFF
--- a/crates/spyglass-processor/src/parser/audio.rs
+++ b/crates/spyglass-processor/src/parser/audio.rs
@@ -250,6 +250,8 @@ pub fn transcibe_audio(
             res.metadata = Some(audio_file.metadata);
 
             let mut params = FullParams::new(SamplingStrategy::default());
+            // Also transcribe to original language
+            params.set_language(Some("auto"));
             params.set_max_len(segment_len);
             params.set_print_progress(false);
             params.set_token_timestamps(true);


### PR DESCRIPTION
- Fixes issue where non-english audio gets translated to english which is neat but not intended.