### PR TITLE
Update iframe link properties

### DIFF
--- a/apps/web/src/pages/landing.rs
+++ b/apps/web/src/pages/landing.rs
@@ -92,8 +92,8 @@ pub fn landing_page(props: &LandingPageProps) -> Html {
                     class="rounded-lg"
                     width="560"
                     height="315"
-                    src="https://www.youtube.com/embed/S0kxrb1oVM0"
-                    title="YouTube video player"
+                    src="https://www.youtube.com/embed/S0kxrb1oVM0?color=red&modestbranding=1&rel=0"
+                    title="Spyglass AI Demo"
                     frameborder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                     allowfullscreen={true}


### PR DESCRIPTION
Update iframe link to use modest branding and only show videos that are related to the account the original video was published from (spyglass only)