### PR TITLE
feat: add option to close search bar

### DIFF
--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -98,6 +98,8 @@ pub struct UserSettings {
     pub allow_list: Vec<String>,
     /// Domains explicitly blocked from crawling.
     pub block_list: Vec<String>,
+    /// Close search bar instead of hiding it
+    pub close_search_bar: bool,
     /// Search bar activation hot key
     #[serde(default = "UserSettings::default_shortcut")]
     pub shortcut: String,
@@ -179,6 +181,13 @@ impl From<UserSettings> for Vec<(String, SettingOpts)> {
                 restart_required: false,
                 help_text: Some("Prevents Spyglass from automatically launching when your computer first starts up.".into())
             }),
+            ("_.close_search_bar".into(), SettingOpts {
+                label: "Close search bar window".into(),
+                value: serde_json::to_string(&settings.close_search_bar).expect("Unable to set close_search_bar value"),
+                form_type: FormType::Bool,
+                restart_required: true,
+                help_text: Some("Close the search bar window instead of minimizing it. Note that using this setting will make it impossible to close the search bar using the shortcut to open it, so you will need to use `Escape` instead. This will require a restart.".into())
+            }),
             ("_.shortcut".into(), SettingOpts {
                 label: "Global Shortcut".into(),
                 value: settings.shortcut.clone(),
@@ -251,6 +260,7 @@ impl Default for UserSettings {
             run_wizard: false,
             allow_list: Vec::new(),
             block_list: vec!["web.archive.org".to_string()],
+            close_search_bar: false,
             // Activation shortcut
             shortcut: UserSettings::default_shortcut(),
             // Where to store the metadata & index

--- a/crates/tauri/src/cmd/settings.rs
+++ b/crates/tauri/src/cmd/settings.rs
@@ -50,6 +50,10 @@ pub async fn save_user_settings(
                                         current_settings.disable_autolaunch =
                                             serde_json::from_str(value).unwrap_or_default();
                                     }
+                                    "close_search_bar" => {
+                                        current_settings.close_search_bar =
+                                            serde_json::from_str(value).unwrap_or_default();
+                                    }
                                     "disable_telemetry" => {
                                         current_settings.disable_telemetry =
                                             serde_json::from_str(value).unwrap_or_default();

--- a/crates/tauri/src/main.rs
+++ b/crates/tauri/src/main.rs
@@ -365,9 +365,13 @@ fn register_global_shortcut(window: &Window, app_handle: &AppHandle, settings: &
             if !is_registered {
                 log::info!("Registering {} as shortcut", &settings.shortcut);
                 let app_hand = app_handle.clone();
+                let should_hide_search_bar = !settings.close_search_bar.clone();
                 if let Err(e) = shortcuts.register(&settings.shortcut, move || {
                     let window = window::get_searchbar(&app_hand);
-                    if platform::is_visible(&window) {
+                    // `platform::is_visible()` returns `true` on Windows when
+                    // the search bar is built, so we cannot really know if the
+                    // window is visible when the `close_search_bar` setting is used.
+                    if should_hide_search_bar && platform::is_visible(&window) {
                         window::hide_search_bar(&window)
                     } else {
                         window::show_search_bar(&window);

--- a/crates/tauri/src/window.rs
+++ b/crates/tauri/src/window.rs
@@ -1,6 +1,7 @@
 use crate::constants::{TabLocation, SETTINGS_WIN_NAME};
 use crate::menu::get_app_menu;
 use crate::{constants, platform};
+use shared::config::Config;
 use shared::event::{ClientEvent, ModelStatusPayload};
 use shared::metrics::Metrics;
 use tauri::api::dialog::{MessageDialogBuilder, MessageDialogButtons, MessageDialogKind};
@@ -69,6 +70,15 @@ pub fn hide_search_bar(window: &Window) {
         if settings_window.is_visible().unwrap_or_default() {
             return;
         }
+    }
+
+    if let Some(config) = handle.try_state::<Config>() {
+        if config.user_settings.close_search_bar {
+            let _ = window.close();
+            return;
+        }
+    } else {
+        log::error!("Unable to get the `close_search_bar` settings");
     }
 
     platform::hide_search_bar(window);


### PR DESCRIPTION
Closes #408

This PR adds an option to close the search bar instead of hiding it.

A few things to note:

- On Windows, when the search bar is built using `window::get_searchbar()`, the `platform::is_visible()` function returns `true` (because `lpwndpl.showCmd == SHOW_WINDOW_CMD(1)` apparently). So, I had to remove the ability to close the search bar using the "open search bar shortcut" when the close search bar setting is on. This could probably be avoided by using the [is_minimized()](https://docs.rs/tauri/1.3.0/tauri/window/struct.Window.html#method.is_minimized) method introduced in tauri v1.3.0.
- The setting requires a restart, because I did not wanted to fight against the lifetime that comes with the addition of `settings` to the `shortcuts.register()` closure (see `crates/tauri/src/main.rs` changes). I could use `app_hand.try_state::<Config>()` to retrieve the setting tho, let me know if you want me to change this.
- Only Windows has been tested. Not MacOS, nor Linux.