### PR TITLE
Include .env file and /dist folder within setup-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ setup-dev:
 	curl -L --output whisper.base.en.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin;
 	mv whisper.base.en.bin assets/models;
 # Check if .env exists and if not create it
-	cp -n .env.template .env
+	test -f .env || cp .env.template .env
 # Check if /dist folder exists for Tauri and if not create it
 	mkdir -p ./crates/tauri/dist
 

--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,10 @@ setup-dev:
 	mkdir -p assets/models;
 	curl -L --output whisper.base.en.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin;
 	mv whisper.base.en.bin assets/models;
+# Check if .env exists and if not create it
+	cp -n .env.template .env
+# Check if /dist folder exists for Tauri and if not create it
+	mkdir -p ./crates/tauri/dist
 
 # Specifically for debian based distros
 setup-dev-linux:


### PR DESCRIPTION
When going through the documentation of a new, initial dev setup, there are some errors where some of the env variables are not setup and Tauri app crashes to build because the /dist folder doesn't exist. 

Adding additional checks to see if the file/folder exists for dev setup, if not, then create:
- copying .env.template as an .env file if it doesn't exist
- within setup-dev, make sure Tauri's /dist folder exists before building Tauri app