### PR TITLE
 Simplify Backend Commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,6 +87,8 @@ setup-dev:
 	mkdir -p assets/models;
 	curl -L --output whisper.base.en.bin https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-base.en.bin;
 	mv whisper.base.en.bin assets/models;
+# Build backend to copy binaries for Tauri
+	make build-backend
 
 # Specifically for debian based distros
 setup-dev-linux:
@@ -101,6 +103,9 @@ setup-dev-linux:
 		cmake \
 		libsdl2-dev \
 		clang
+
+run-backend-dev:
+	cargo run -p spyglass
 
 run-client-dev:
 	cargo tauri dev


### PR DESCRIPTION
- adding `build-backend` to the `setup-dev` command to copy binaries to Tauri and not run the `build-release` command
- new command to run backend server to make the "building from source" documentation consistent to only using `make` commands

Updating docs to reflect these changes here: https://github.com/spyglass-search/docs.spyglass.fyi/pull/6