### PR TITLE
Rename app to "Spyglass Dev" for dev instance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ setup-dev-linux:
 		clang
 
 run-client-dev:
-	cargo tauri dev
+	cargo tauri dev --config ./crates/tauri/tauri.dev.conf.json
 
 run-client-headless:
 	cd ./crates/client && HEADLESS_CLIENT=true trunk serve

--- a/crates/tauri/tauri.dev.conf.json
+++ b/crates/tauri/tauri.dev.conf.json
@@ -1,0 +1,5 @@
+{
+  "package": {
+    "productName": "Spyglass Dev"
+  }
+}


### PR DESCRIPTION
In the case that a dev has a local instance of Spyglass running and a Prod instance, they're both named the same app name, "Spyglass".

These changes will make it that the local instance will now be called "Spyglass Dev" to differentiate the two instances.