### PR TITLE
Embedding enable disable

### DIFF
--- a/apps/tauri/src/cmd/settings.rs
+++ b/apps/tauri/src/cmd/settings.rs
@@ -90,6 +90,10 @@ pub async fn save_user_settings(
                                     current_settings.audio_settings.enable_audio_transcription =
                                         serde_json::from_str(value).unwrap_or_default()
                                 }
+                                "embedding_settings.enable_embeddings" => {
+                                    current_settings.embedding_settings.enable_embeddings =
+                                        serde_json::from_str(value).unwrap_or_default()
+                                }
                                 _ => {}
                             }
                         }

--- a/crates/entities/src/models/embedding_queue.rs
+++ b/crates/entities/src/models/embedding_queue.rs
@@ -84,7 +84,12 @@ where
     Entity::insert(model)
         .on_conflict(
             OnConflict::column(Column::DocumentId)
-                .update_columns([Column::Status, Column::Content, Column::IndexedDocumentId])
+                .update_columns([
+                    Column::Status,
+                    Column::Content,
+                    Column::IndexedDocumentId,
+                    Column::UpdatedAt,
+                ])
                 .to_owned(),
         )
         .exec(db)
@@ -98,7 +103,12 @@ where
     Entity::insert_many(to_add.to_vec())
         .on_conflict(
             OnConflict::column(Column::DocumentId)
-                .update_columns([Column::Status, Column::Content, Column::IndexedDocumentId])
+                .update_columns([
+                    Column::Status,
+                    Column::Content,
+                    Column::IndexedDocumentId,
+                    Column::UpdatedAt,
+                ])
                 .to_owned(),
         )
         .exec_without_returning(db)

--- a/crates/entities/src/models/indexed_document.rs
+++ b/crates/entities/src/models/indexed_document.rs
@@ -509,6 +509,20 @@ pub async fn copy_table(
     Ok(())
 }
 
+pub async fn get_documents_missing_embeddings(
+    db: &DatabaseConnection,
+) -> Result<Vec<Model>, DbErr> {
+    let statement = Statement::from_string(
+        db.get_database_backend(),
+        r#"
+         select * from indexed_document where id not in (
+	        select indexed_document_id from embedding_queue where status != 'Failed')
+    "#,
+    );
+
+    Model::find_by_statement(statement).all(db).await
+}
+
 #[cfg(test)]
 mod test {
     use std::collections::HashMap;

--- a/crates/entities/src/models/vec_documents.rs
+++ b/crates/entities/src/models/vec_documents.rs
@@ -40,7 +40,7 @@ where
             db.get_database_backend(),
             r#"
             update vec_documents set embedding = $2
-                where id = $1
+                where rowid = $1
             "#,
             vec![id.into(), embedding.into()],
         )

--- a/crates/shared/src/config.rs
+++ b/crates/shared/src/config.rs
@@ -1,7 +1,7 @@
 use crate::form::{FormType, SettingOpts};
 use diff::Diff;
 use directories::ProjectDirs;
-use embeddings::EmbeddingSettings;
+use embeddings::{embedding_setting_opts, EmbeddingSettings};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -234,6 +234,7 @@ impl From<UserSettings> for Vec<(String, SettingOpts)> {
 
         config.extend(fs_setting_opts(&settings));
         config.extend(audio_setting_opts(&settings));
+        config.extend(embedding_setting_opts(&settings));
 
         config
     }

--- a/crates/shared/src/config/embeddings.rs
+++ b/crates/shared/src/config/embeddings.rs
@@ -5,17 +5,9 @@ use crate::form::{FormType, SettingOpts};
 
 use super::UserSettings;
 
-#[derive(Clone, Debug, Serialize, Deserialize, Diff)]
+#[derive(Clone, Debug, Serialize, Deserialize, Diff, Default)]
 pub struct EmbeddingSettings {
     pub enable_embeddings: bool,
-}
-
-impl Default for EmbeddingSettings {
-    fn default() -> Self {
-        EmbeddingSettings {
-            enable_embeddings: false,
-        }
-    }
 }
 
 #[allow(dead_code)]

--- a/crates/shared/src/config/embeddings.rs
+++ b/crates/shared/src/config/embeddings.rs
@@ -13,7 +13,7 @@ pub struct EmbeddingSettings {
 impl Default for EmbeddingSettings {
     fn default() -> Self {
         EmbeddingSettings {
-            enable_embeddings: true,
+            enable_embeddings: false,
         }
     }
 }
@@ -26,7 +26,7 @@ pub fn embedding_setting_opts(settings: &UserSettings) -> Vec<(String, SettingOp
             label: "Beta: Enable Similarity Search".into(),
             value: settings.embedding_settings.enable_embeddings.to_string(),
             form_type: FormType::Bool,
-            restart_required: true,
+            restart_required: false,
             help_text: Some(
                 r#"Embeddings are generated for documents and search will check for
                    semantic similarity as well as standard search."#

--- a/crates/spyglass-model-interface/src/lib.rs
+++ b/crates/spyglass-model-interface/src/lib.rs
@@ -421,7 +421,8 @@ impl<O> WrapErr<O> for Result<O, candle::Error> {
 pub fn load_tokenizer(model_root: &Path) -> anyhow::Result<Tokenizer> {
     // Load tokenizer
     let tokenizer_path = model_root.join("tokenizer.json");
-    let mut tokenizer = Tokenizer::from_file(tokenizer_path).expect("tokenizer.json not found");
+    let mut tokenizer = Tokenizer::from_file(tokenizer_path)
+        .map_err(|error| anyhow::format_err!("Error loading tokenizer {:?}", error))?;
     // See https://github.com/huggingface/tokenizers/pull/1357
     if let Some(pre_tokenizer) = tokenizer.get_pre_tokenizer() {
         if let PreTokenizerWrapper::Metaspace(m) = pre_tokenizer {

--- a/crates/spyglass/src/api/handler/search.rs
+++ b/crates/spyglass/src/api/handler/search.rs
@@ -62,7 +62,7 @@ pub async fn search_docs(
         }));
     }
 
-    if let Some(embedding_api) = state.embedding_api.as_ref() {
+    if let Some(embedding_api) = state.embedding_api.load_full().as_ref() {
         match embedding_api.embed(&query, EmbeddingContentType::Query) {
             Ok(embedding) => {
                 let mut distances =

--- a/crates/spyglass/src/documents/embeddings.rs
+++ b/crates/spyglass/src/documents/embeddings.rs
@@ -18,7 +18,7 @@ pub async fn processing_embedding(state: AppState, job_id: i64) {
         Ok(Some(job)) => {
             match job.content {
                 Some(content) => {
-                    let embedding = if let Some(api) = state.embedding_api.as_ref() {
+                    let embedding = if let Some(api) = state.embedding_api.load_full().as_ref() {
                         api.embed(&content, EmbeddingContentType::Document)
                     } else {
                         Err(anyhow::format_err!(

--- a/crates/spyglass/src/documents/mod.rs
+++ b/crates/spyglass/src/documents/mod.rs
@@ -194,7 +194,7 @@ pub async fn process_crawl_results(
             )
             .await?;
 
-        if crawl_result.content.is_some() && state.embedding_api.as_ref().is_some() {
+        if crawl_result.content.is_some() && state.embedding_api.load().as_ref().is_some() {
             embedding_map.insert(doc_id.clone(), crawl_result.content.clone().unwrap());
         }
 


### PR DESCRIPTION
- Add embedding enable / disable to the settings page
- Auto download the model if needed when embeddings are enabled
- When enabled auto add all indexed documents that have not had embeddings generated to the embedding queue
- Update embedding api to be swapable, this allows the model to be reloaded after download